### PR TITLE
feat(usemodal): re-exposes original setValue in boolean hooks

### DIFF
--- a/src/useBoolean/useBoolean.stories.tsx
+++ b/src/useBoolean/useBoolean.stories.tsx
@@ -14,6 +14,8 @@ export interface UseBooleanDocsProps {
  * returns the value, an object containing function for toggle, setTrue and setFalse.
  *
  * __Use `toggle` with caution__, attaching to buttons can cause unintended consequences from double clicks.
+ * Also, re-exposes the `setValue` function in case required.
+ *
  */
 export const UseBooleanDocs: React.FC<UseBooleanDocsProps> = (
   _props: UseBooleanDocsProps

--- a/src/useBoolean/useBoolean.ts
+++ b/src/useBoolean/useBoolean.ts
@@ -14,6 +14,7 @@ export function useBoolean(startState = false): [
     toggle: () => void
     setTrue: () => void
     setFalse: () => void
+    setValue: React.Dispatch<React.SetStateAction<boolean>>
   }
 ] {
   const [value, setValue] = useState(startState)
@@ -23,6 +24,7 @@ export function useBoolean(startState = false): [
       toggle: (): void => setValue((state) => !state),
       setTrue: (): void => setValue(true),
       setFalse: (): void => setValue(false),
+      setValue,
     }),
     [setValue]
   )

--- a/src/useModal/useModal.stories.tsx
+++ b/src/useModal/useModal.stories.tsx
@@ -12,6 +12,7 @@ export interface UseModalDocsProps {
  * Utility hook for modal state
  *
  * returns the visibility of the modal and functions to `show` and `hide`.
+ * Also, re-exposes the `set` function in case required.
  *
  */
 export const UseModalDocs: React.FC<UseModalDocsProps> = (

--- a/src/useModal/useModal.ts
+++ b/src/useModal/useModal.ts
@@ -9,7 +9,13 @@ import { useBoolean } from '../useBoolean'
  */
 export function useModal(
   startState = false
-): [visible: boolean, show: () => void, hide: () => void] {
-  const [visible, { setTrue: show, setFalse: hide }] = useBoolean(startState)
-  return [visible, show, hide]
+): [
+  visible: boolean,
+  show: () => void,
+  hide: () => void,
+  set: React.Dispatch<React.SetStateAction<boolean>>
+] {
+  const [visible, { setTrue: show, setFalse: hide, setValue: set }] =
+    useBoolean(startState)
+  return [visible, show, hide, set]
 }


### PR DESCRIPTION
For cases where it might be simpler to pass the original setValue this is re-exposed.

